### PR TITLE
remove the test for setting server_name on nginx::resource::streamhost

### DIFF
--- a/spec/defines/resource_stream_spec.rb
+++ b/spec/defines/resource_stream_spec.rb
@@ -88,12 +88,6 @@ describe 'nginx::resource::streamhost' do
           :match => %r'\s+listen\s+\[::\]:80 spdy;',
         },
         {
-          :title => 'should set servername(s)',
-          :attr  => 'server_name',
-          :value => ['www.foo.com','foo.com'],
-          :match => %r'\s+server_name\s+www.foo.com foo.com;',
-        },
-        {
           :title => 'should contain raw_prepend directives',
           :attr  => 'raw_prepend',
           :value => [


### PR DESCRIPTION
remove the test for setting server_name for the nginx::resource::streamhost defined type as it's no longer a supported parameter.

This should fix the travisci failure on the PR into the jfryman/puppet-nginx repository
